### PR TITLE
Web UI fetch yaml

### DIFF
--- a/cli/medperf/web_ui/templates/mlcube_detail.html
+++ b/cli/medperf/web_ui/templates/mlcube_detail.html
@@ -78,9 +78,9 @@
                 </div>
                 <div class="card mb-3">
                     <div class="card-body">
-                        <p class="card-text"><strong>MLCube:</strong> <a href="{{ entity.git_mlcube_url }}" class="text-primary yaml-link" target="_blank">{{ entity.git_mlcube_url }}</a></p>
+                        <p class="card-text"><strong>MLCube:</strong> <a href="{{ entity.git_mlcube_url }}" data-id="{{ entity.id }}" data-field="git_mlcube_url" class="text-primary yaml-link" target="_blank">{{ entity.git_mlcube_url }}</a></p>
                         <p class="card-text text-muted small">{{ entity.mlcube_hash }}</p>
-                        <p class="card-text"><strong>Parameters:</strong> <a href="{{ entity.git_parameters_url }}" class="text-primary yaml-link" target="_blank">{{ entity.git_parameters_url }}</a></p>
+                        <p class="card-text"><strong>Parameters:</strong> <a href="{{ entity.git_parameters_url }}" data-id="{{ entity.id }}" data-field="git_parameters_url" class="text-primary yaml-link" target="_blank">{{ entity.git_parameters_url }}</a></p>
                         <p class="card-text text-muted small">{{ entity.parameters_hash }}</p>
                         {% if entity.image_tarball_url %}
                             <p class="card-text"><strong>Image Tarball:</strong> <a href="{{ entity.image_tarball_url }}" class="text-primary" target="_blank">{{ entity.image_tarball_url }}</a></p>
@@ -134,12 +134,13 @@
     document.addEventListener('DOMContentLoaded', function() {
         $('.yaml-link').on('click', function(event) {
             event.preventDefault();
-            const url = $(this).attr('href');
+            const id = $(this).data('id');
+            const field = $(this).data('field');
             $('#yaml-panel').show();
             $('.yaml-container').addClass('yaml-panel-visible');
             $('#loading-indicator').show();
             $('#yaml-code').hide();
-            $.get('/fetch-yaml', { url: url }, function(data) {
+            $.get('/fetch-yaml', { mlcube_uid: id, field_to_fetch: field}, function(data) {
                 $('#yaml-code').text(data.content);
                 Prism.highlightElement($('#yaml-code')[0]);
                 $('#loading-indicator').hide();

--- a/cli/medperf/web_ui/yaml_fetch/routes.py
+++ b/cli/medperf/web_ui/yaml_fetch/routes.py
@@ -1,13 +1,21 @@
+from enum import Enum
 from fastapi import APIRouter, HTTPException
+from medperf.entities.cube import Cube
 import requests
 import yaml
 
 router = APIRouter()
 
+class FieldsToFetch(Enum):
+   mlcube_yaml = "git_mlcube_url"
+   param_yaml = "git_parameters_url"
+
 
 @router.get("/fetch-yaml")
-async def fetch_yaml(url: str):
+async def fetch_yaml(mlcube_uid: int, field_to_fetch: FieldsToFetch):
     try:
+        mlcube = Cube.get(mlcube_uid)
+        url = getattr(mlcube, field_to_fetch.value)
         response = requests.get(url)
         response.raise_for_status()  # Check if the request was successful
         content = response.text


### PR DESCRIPTION
This PR fixes the issue of passing an arbitrary URL to the server, by passing instead MLCube parameters to `/fetch-yaml` that can be used to retrieve the desired URL internally. This should fix the security vulnerability.